### PR TITLE
params: make userID a query parameter in /v1/uid endpoints

### DIFF
--- a/internal/v1/users_test.go
+++ b/internal/v1/users_test.go
@@ -1102,7 +1102,7 @@ var getUserWithIDTests = []struct {
 }, {
 	about:       "no such user",
 	userid:      "test:not-there",
-	expectError: `Get .*/v1/uid/test:not-there: identity "test:not-there" not found`,
+	expectError: `Get .*/v1/uid\?id=test%3Anot-there: identity "test:not-there" not found`,
 }}
 
 func (s *usersSuite) TestGetUserWithID(c *qt.C) {
@@ -1154,7 +1154,7 @@ var getUserIDGroupsTests = []struct {
 }, {
 	about:       "no such user",
 	userid:      "test:not-there",
-	expectError: `Get .*/v1/uid/test:not-there/groups: identity "test:not-there" not found`,
+	expectError: `Get .*/v1/uid/groups\?id=test%3Anot-there: identity "test:not-there" not found`,
 }}
 
 func (s *usersSuite) TestGetUserIDGroups(c *qt.C) {

--- a/params/params.go
+++ b/params/params.go
@@ -328,15 +328,15 @@ type IDPChoiceDetails struct {
 // GetUserWithIDRequest is a request for the user details of the user with the
 // given ID.
 type GetUserWithIDRequest struct {
-	httprequest.Route `httprequest:"GET /v1/uid/:UserID"`
-	UserID            string `httprequest:",path"`
+	httprequest.Route `httprequest:"GET /v1/uid"`
+	UserID            string `httprequest:"id,form"`
 }
 
 // GetUserGroupsWithIDRequest is a request for the groups of the user with the
 // given ID.
 type GetUserGroupsWithIDRequest struct {
-	httprequest.Route `httprequest:"GET /v1/uid/:UserID/groups"`
-	UserID            string `httprequest:",path"`
+	httprequest.Route `httprequest:"GET /v1/uid/groups"`
+	UserID            string `httprequest:"id,form"`
 }
 
 // GroupsResponse is the response to a GetUserGroupsWithIDRequest.


### PR DESCRIPTION
The userID is intended to be a system-wide unique value for the user,
separate from username. Such values may be comprised partly from URLs
this makes them hard to process as a path segment.