### PR TITLE
idp/openid: fix registration step.

### DIFF
--- a/idp/idputil/idputil.go
+++ b/idp/idputil/idputil.go
@@ -140,6 +140,10 @@ func NameWithDomain(name, domain string) string {
 // whilst a login is being processed.
 const LoginCookieName = "candid-login"
 
+// LoginCookiePath is the path to associate with the cookie storing the
+// current login state.
+const LoginCookiePath = "/login"
+
 // LoginState holds the state of the current loging process.
 type LoginState struct {
 	// ReturnTo holds the address to return to after the login has

--- a/idp/idputil/secret/codec.go
+++ b/idp/idputil/secret/codec.go
@@ -118,7 +118,7 @@ func (c *Codec) decrypt(out, in []byte) ([]byte, error) {
 // SetCookie encodes the given value as a session cookie with the given
 // name. The returned value is used the verify the cookie later - it
 // should be passed to Cookie when the cookie is retrieved.
-func (c *Codec) SetCookie(w http.ResponseWriter, name string, v interface{}) (string, error) {
+func (c *Codec) SetCookie(w http.ResponseWriter, name, path string, v interface{}) (string, error) {
 	out, err := c.encode(v)
 	if err != nil {
 		return "", errgo.Mask(err)
@@ -127,6 +127,7 @@ func (c *Codec) SetCookie(w http.ResponseWriter, name string, v interface{}) (st
 	http.SetCookie(w, &http.Cookie{
 		Name:  name,
 		Value: base64.URLEncoding.EncodeToString(out),
+		Path:  path,
 	})
 	return base64.RawURLEncoding.EncodeToString(hash[:]), nil
 }

--- a/idp/idputil/secret/codec_test.go
+++ b/idp/idputil/secret/codec_test.go
@@ -145,7 +145,7 @@ func TestCookieRoundTrip(t *testing.T) {
 	}
 	a.A = 1
 	a.B = "test"
-	verification, err := codec.SetCookie(w, "test-cookie", a)
+	verification, err := codec.SetCookie(w, "test-cookie", "/", a)
 	c.Assert(err, qt.IsNil)
 	resp := w.Result()
 	defer resp.Body.Close()
@@ -180,7 +180,7 @@ func TestCookieDecodeError(t *testing.T) {
 	}
 	a.A = 1
 	a.B = "test"
-	_, err := codec.SetCookie(w, "test-cookie", a)
+	_, err := codec.SetCookie(w, "test-cookie", "/", a)
 	c.Assert(err, qt.IsNil)
 	resp := w.Result()
 	defer resp.Body.Close()
@@ -206,7 +206,7 @@ func TestCookieValidationError(t *testing.T) {
 	}
 	a.A = 1
 	a.B = "test"
-	_, err := codec.SetCookie(w, "test-cookie", a)
+	_, err := codec.SetCookie(w, "test-cookie", "/", a)
 	c.Assert(err, qt.IsNil)
 	resp := w.Result()
 	defer resp.Body.Close()

--- a/idp/openid/openid-connect.go
+++ b/idp/openid/openid-connect.go
@@ -223,7 +223,7 @@ func (idp *openidConnectIdentityProvider) callback(ctx context.Context, w http.R
 		return errgo.Mask(err)
 	}
 	ls.ProviderID = user.ProviderID
-	state, err := idp.initParams.Codec.SetCookie(w, idputil.LoginCookieName, ls)
+	state, err := idp.initParams.Codec.SetCookie(w, idputil.LoginCookieName, idputil.LoginCookiePath, ls)
 	if err != nil {
 		return errgo.Mask(err)
 	}

--- a/internal/discharger/login.go
+++ b/internal/discharger/login.go
@@ -73,7 +73,7 @@ func (h *handler) Login(p httprequest.Params, req *loginRequest) error {
 	// Store the requested discharge ID in a session cookie so that
 	// when the redirect comes back to login-complete we know the
 	// login was initiated in this session.
-	state, err := h.params.codec.SetCookie(p.Response, waitCookieName, waitState{
+	state, err := h.params.codec.SetCookie(p.Response, waitCookieName, "/login-complete", waitState{
 		DischargeID: req.DischargeID,
 	})
 	if err != nil {
@@ -113,7 +113,7 @@ type redirectLoginRequest struct {
 // identity provider which the user must then choose to start the login
 // process.
 func (h *handler) RedirectLogin(p httprequest.Params, req *redirectLoginRequest) error {
-	state, err := h.params.codec.SetCookie(p.Response, idputil.LoginCookieName, idputil.LoginState{
+	state, err := h.params.codec.SetCookie(p.Response, idputil.LoginCookieName, idputil.LoginCookiePath, idputil.LoginState{
 		ReturnTo: req.ReturnTo,
 		State:    req.State,
 		Expires:  time.Now().Add(15 * time.Minute),

--- a/templates/register
+++ b/templates/register
@@ -37,6 +37,7 @@
             </div>
           {{end}}
           <form class="p-form" method="post" action="register">
+            <input type="hidden" name="state" value="{{.State}}">
             <label for="username">Username</label>
             <input type="text" id="username" name="username" class="js_username_input" autocomplete="off">
             <p class="p-form-help-text"><span class="js_username_output"></span>@{{.Domain}}</p>


### PR DESCRIPTION
If an OpenID Connect login requires the user to register then the
login attempt would fail. The login process now makes sure that all
"candid-login" cookies are created with the same path. Also the
registration template ensures the state parameter is echoed back.