### PR TITLE
internal/discharger: change short-term stores

### DIFF
--- a/internal/discharger/export_test.go
+++ b/internal/discharger/export_test.go
@@ -9,17 +9,17 @@ import (
 	"github.com/canonical/candid/idp"
 	"github.com/canonical/candid/internal/discharger/internal"
 	"github.com/canonical/candid/internal/identity"
+	"github.com/canonical/candid/store"
 )
 
 var NewIDPHandler = newIDPHandler
 
 type LoginInfo loginInfo
 
-func NewVisitCompleter(params identity.HandlerParams, store simplekv.Store) idp.VisitCompleter {
+func NewVisitCompleter(params identity.HandlerParams, kvstore simplekv.Store, store store.Store) idp.VisitCompleter {
 	return &visitCompleter{
-		params:                params,
-		dischargeTokenCreator: &dischargeTokenCreator{params: params},
-		dischargeTokenStore:   internal.NewDischargeTokenStore(store),
-		place:                 &place{params.MeetingPlace},
+		params:        params,
+		identityStore: internal.NewIdentityStore(kvstore, store),
+		place:         &place{params.MeetingPlace},
 	}
 }

--- a/internal/discharger/idp_test.go
+++ b/internal/discharger/idp_test.go
@@ -72,7 +72,7 @@ func (s *idpSuite) Init(c *qt.C) {
 		},
 		MeetingPlace: s.meetingPlace,
 		Oven:         oven,
-	}, kvs)
+	}, kvs, s.store.Store)
 }
 
 func (s *idpSuite) TestLoginFailure(c *qt.C) {
@@ -112,7 +112,7 @@ func (s *idpSuite) TestLoginFailureWithWait(c *qt.C) {
 	var li discharger.LoginInfo
 	err = json.Unmarshal(d2, &li)
 	c.Assert(err, qt.IsNil)
-	c.Assert(li.DischargeToken, qt.IsNil)
+	c.Assert(li.ProviderID, qt.Equals, store.ProviderIdentity(""))
 	c.Assert(li.Error, qt.DeepEquals, &httpbakery.Error{
 		Message: "test error",
 	})

--- a/internal/discharger/login.go
+++ b/internal/discharger/login.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/canonical/candid/idp/idputil"
 	"github.com/canonical/candid/params"
+	"github.com/canonical/candid/store"
 )
 
 // legacyLoginRequest is a request to start a login to the identity manager
@@ -202,13 +203,13 @@ func (h *handler) LoginComplete(p httprequest.Params, req *loginCompleteRequest)
 		return
 	}
 
-	dt, err := h.params.dischargeTokenStore.Get(ctx, req.Code)
-	if err != nil {
+	var id store.Identity
+	if err := h.params.identityStore.Get(ctx, req.Code, &id); err != nil {
 		h.params.visitCompleter.Failure(ctx, p.Response, p.Request, ws.DischargeID, err)
 		return
 	}
 
-	h.params.visitCompleter.successToken(ctx, p.Response, p.Request, ws.DischargeID, dt, nil)
+	h.params.visitCompleter.Success(ctx, p.Response, p.Request, ws.DischargeID, &id)
 }
 
 const waitCookieName = "candid-discharge-wait"

--- a/internal/discharger/meeting.go
+++ b/internal/discharger/meeting.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/canonical/candid/meeting"
+	"github.com/canonical/candid/store"
 )
 
 type dischargeRequestInfo struct {
@@ -21,10 +22,8 @@ type dischargeRequestInfo struct {
 }
 
 type loginInfo struct {
-	// When a user logs in successfully, a discharge token is
-	// provided which grants them the right to discharge macaroons as
-	// that user.
-	DischargeToken *httpbakery.DischargeToken
+	// When a user logs in successfully their ProviderID will be supplied.
+	ProviderID store.ProviderIdentity
 
 	// When a login request fails, the error is filled out appropriately.
 	Error *httpbakery.Error


### PR DESCRIPTION
Change the types stored in the short-term data stores used in the login
protocol to store an Identites unmodifiable ProviderID rather that a
DischargeToken. DischargeTokens are now only created when they are
needed. This is a preliminary branch to support using ProviderIDs in the
discharge tokens.

Please note that, while this change is isolated to the discharge
package, some in-progress logins that are happening at the time of
upgrade to this code may fail. If logins do fail then they will work
if retryed immediately afterwards.