### PR TITLE
internal/discharger: discharge token unique ID

### DIFF
--- a/internal/discharger/idp.go
+++ b/internal/discharger/idp.go
@@ -85,7 +85,7 @@ func (d *dischargeTokenCreator) DischargeToken(ctx context.Context, id *store.Id
 		bakery.LatestVersion,
 		[]checkers.Caveat{
 			checkers.TimeBeforeCaveat(time.Now().Add(d.params.DischargeTokenTimeout)),
-			candidclient.UserDeclaration(id.Username),
+			candidclient.UserIDDeclaration(string(id.ProviderID)),
 		},
 		identchecker.LoginOp,
 	)

--- a/internal/discharger/wait.go
+++ b/internal/discharger/wait.go
@@ -78,7 +78,7 @@ func (h *handler) WaitLegacy(p httprequest.Params, req *waitRequest) (*waitRespo
 	//
 	// however... why can't we just add the origin caveat when we create
 	// the discharge token? the problem with that is that the callers of
-	// DischargeToken don't neceessarily have access to the original origin
+	// DischargeToken don't necessarily have access to the original origin
 	// (because they might be creating the token in response to a callback
 	// from an external identity provider, for example).
 	m, err := bakery.Discharge(p.Context, bakery.DischargeParams{


### PR DESCRIPTION
Use the unique and immutable ProviderID in new discharge tokens. Old
username-based discharge tokens will still work.