### PR TITLE
Created a generic keycloak openidc idp

### DIFF
--- a/cmd/candidsrv/main.go
+++ b/cmd/candidsrv/main.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/canonical/candid/idp/agent"
 	_ "github.com/canonical/candid/idp/azure"
 	_ "github.com/canonical/candid/idp/google"
+	_ "github.com/canonical/candid/idp/keycloak"
 	_ "github.com/canonical/candid/idp/keystone"
 	_ "github.com/canonical/candid/idp/ldap"
 	_ "github.com/canonical/candid/idp/static"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -314,6 +314,32 @@ The `hidden` value is an optional value that can be used to not list
 this identity provider in the list of possible identity providers when
 performing an interactive login.
 
+### Keycloak OpenID Connect
+```yaml
+- type: keycloak
+  domain: example
+  client-id: 483156874216
+  client-secret: 32hf3uhud23dS@#e
+  keycloak-realm: https://example.com/auth/realms/example
+  hidden: false
+```
+
+The Keycloak identity provider uses OpenID Connect to log in using configured
+credentials. When a user first logs in with this IDP they will be prompted
+to create a new identity. The new identity must have a unique username
+and will be in the domain specified "@domain", otherwise default to "@KEYCLOAK".
+
+The 'keycloak-realm, `client-id`, and `client-secret` parameters 
+must be specified and should be provided by the keycloak service administrator.
+
+When registering the application the authorized redirect URLs should include
+`$CANDID_URL/login/keycloak/callback`.
+
+The `hidden` value is an optional value that can be used to not list
+this identity provider in the list of possible identity providers when
+performing an interactive login.
+```
+
 ### LDAP
 ```yaml
 - type: ldap

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -329,8 +329,9 @@ credentials. When a user first logs in with this IDP they will be prompted
 to create a new identity. The new identity must have a unique username
 and will be in the domain specified "@domain", otherwise default to "@KEYCLOAK".
 
-The 'keycloak-realm, `client-id`, and `client-secret` parameters 
-must be specified and should be provided by the keycloak service administrator.
+The 'keycloak-realm and `client-id` parameters must be specified and should be 
+provided by the keycloak service administrator. An optional client-secret may
+also be required which the keycloak service administrator should provide.
 
 When registering the application the authorized redirect URLs should include
 `$CANDID_URL/login/keycloak/callback`.

--- a/idp/keycloak/keycloak.go
+++ b/idp/keycloak/keycloak.go
@@ -1,0 +1,86 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package keycloak is an identity provider that authenticates with keycloak oidc.
+package keycloak
+
+import (
+	oidc "github.com/coreos/go-oidc"
+	"gopkg.in/errgo.v1"
+
+	"github.com/canonical/candid/idp"
+	"github.com/canonical/candid/idp/openid"
+)
+
+func init() {
+	idp.Register("keycloak", func(unmarshal func(interface{}) error) (idp.IdentityProvider, error) {
+		var p Params
+		if err := unmarshal(&p); err != nil {
+			return nil, errgo.Notef(err, "cannot unmarshal keycloak parameters")
+		}
+		if p.ClientID == "" {
+			return nil, errgo.Newf("client-id not specified")
+		}
+		if p.ClientSecret == "" {
+			return nil, errgo.Newf("client-secret not specified")
+		}
+		if p.KeycloakRealm == "" {
+			return nil, errgo.Newf("keycloak-realm not specified")
+		}
+		return NewIdentityProvider(p), nil
+	})
+}
+
+type Params struct {
+	// Name is the name that will be given to the identity provider.
+	Name string `yaml:"name"`
+
+	// Description is the description that will be used with the
+	// identity provider. If this is not set then Name will be used.
+	Description string `yaml:"description"`
+
+	// Icon contains the URL or path of an icon.
+	Icon string `yaml:"icon"`
+
+	// Domain is the domain with which all identities created by this
+	// identity provider will be tagged (not including the @ separator).
+	Domain string `yaml:"domain"`
+
+	// ClientID contains the Application Id for the application
+	// registered at
+	ClientID string `yaml:"client-id"`
+
+	// ClientSecret contains a password type Application Secret for
+	// the application as generated on
+	ClientSecret string `yaml:"client-secret"`
+
+	// KeycloakReam contains the URI for the keycloak server
+	// https://<keycloakserver>/auth/realms/<keycloakdomain>
+	KeycloakRealm string `yaml:"keycloak-realm"`
+
+	// Hidden is set if the IDP should be hidden from interactive
+	// prompts.
+	Hidden bool `yaml:"hidden"`
+}
+
+// NewIdentityProvider creates a keycloak identity provider with the
+// configuration defined by p.
+func NewIdentityProvider(p Params) idp.IdentityProvider {
+	if p.Name == "" {
+		p.Name = "keycloak"
+	}
+	if p.Domain == "" {
+		p.Domain = "KEYCLOAK"
+	}
+	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
+		Name:         p.Name,
+		Issuer:       p.KeycloakRealm,
+		Domain:       p.Domain,
+		Description:  p.Description,
+		Icon:         p.Icon,
+		Scopes:       []string{oidc.ScopeOpenID, "profile"},
+		ClientID:     p.ClientID,
+		ClientSecret: p.ClientSecret,
+		Hidden:       p.Hidden,
+	})
+}

--- a/idp/keycloak/keycloak.go
+++ b/idp/keycloak/keycloak.go
@@ -21,9 +21,6 @@ func init() {
 		if p.ClientID == "" {
 			return nil, errgo.Newf("client-id not specified")
 		}
-		if p.ClientSecret == "" {
-			return nil, errgo.Newf("client-secret not specified")
-		}
 		if p.KeycloakRealm == "" {
 			return nil, errgo.Newf("keycloak-realm not specified")
 		}
@@ -47,11 +44,11 @@ type Params struct {
 	Domain string `yaml:"domain"`
 
 	// ClientID contains the Application Id for the application
-	// registered at
+	// registered
 	ClientID string `yaml:"client-id"`
 
-	// ClientSecret contains a password type Application Secret for
-	// the application as generated on
+	// Optional: ClientSecret contains a password type Application Secret
+	// for the application generated
 	ClientSecret string `yaml:"client-secret"`
 
 	// KeycloakReam contains the URI for the keycloak server

--- a/idp/keycloak/keycloak.go
+++ b/idp/keycloak/keycloak.go
@@ -1,3 +1,4 @@
+// Copyright 2020 Mark Klein <mdklein@gmail.com>
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 
@@ -10,6 +11,11 @@ import (
 
 	"github.com/canonical/candid/idp"
 	"github.com/canonical/candid/idp/openid"
+)
+
+const (
+	defaultProviderName = "keycloak"
+	defaultProviderDomain = "KEYCLOAK"
 )
 
 func init() {
@@ -28,6 +34,7 @@ func init() {
 	})
 }
 
+// Params is a struct containing the configuration data to register a keycloak identity Provider
 type Params struct {
 	// Name is the name that will be given to the identity provider.
 	Name string `yaml:"name"`
@@ -63,11 +70,12 @@ type Params struct {
 // NewIdentityProvider creates a keycloak identity provider with the
 // configuration defined by p.
 func NewIdentityProvider(p Params) idp.IdentityProvider {
+
 	if p.Name == "" {
-		p.Name = "keycloak"
+		p.Name = defaultProviderName
 	}
 	if p.Domain == "" {
-		p.Domain = "KEYCLOAK"
+		p.Domain = defaultProviderDomain
 	}
 	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
 		Name:         p.Name,

--- a/idp/keycloak/keycloak_test.go
+++ b/idp/keycloak/keycloak_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package keycloak_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"gopkg.in/yaml.v2"
+
+	"github.com/canonical/candid/config"
+)
+
+var configTests = []struct {
+	about				string
+	yaml				string
+	expectError string
+}{{
+	about: "good config",
+	yaml: `
+identity-providers:
+ - type: keycloak 
+	 client-id: client-001
+	 client-secret: secret-001
+	 keycloak-realm: https://example.com/auth/realms/example
+	 domain: example
+`,
+}, {
+	about: "no client-id",
+	yaml: `
+identity-providers:
+ - type: keycloak 
+	 client-secret: secret-001
+	 keycloak-realm: https://example.com/auth/realms/example
+`,
+	expectError: `cannot unmarshal keycloak configuration: client-id not specified`,
+}, {
+	about: "no client-secret",
+	yaml: `
+identity-providers:
+ - type: keycloak 
+	 client-id: client-001
+	 keycloak-realm: https://example.com/auth/realms/example
+`,
+	expectError: `cannot unmarshal keycloak configuration: client-secret not specified`,
+},{
+	about: "no keycloak-realm",
+	yaml: `
+identity-providers:
+ - type: keycloak
+	 client-id: client-001
+	 client-secret: secret-001
+`,
+	expectError: `cannot unmarshal keycloak configuration: keycloak-realm not specified`,
+}
+}
+
+func TestConfig(t *testing.T) {
+	c := qt.New(t)
+	for _, test := range configTests {
+		c.Run(test.about, func(c *qt.C) {
+			var conf config.Config
+			err := yaml.Unmarshal([]byte(test.yaml), &conf)
+			if test.expectError != "" {
+				c.Assert(err, qt.ErrorMatches, test.expectError)
+				return
+			}
+			c.Assert(err, qt.Equals, nil)
+			c.Assert(conf.IdentityProviders, qt.HasLen, 1)
+			c.Assert(conf.IdentityProviders[0].Name(), qt.Equals, "keycloak")
+		})
+	}
+}

--- a/idp/keycloak/keycloak_test.go
+++ b/idp/keycloak/keycloak_test.go
@@ -13,26 +13,25 @@ import (
 )
 
 var configTests = []struct {
-	about				string
-	yaml				string
+	about       string
+	yaml        string
 	expectError string
 }{{
 	about: "good config",
 	yaml: `
 identity-providers:
  - type: keycloak 
-	 client-id: client-001
-	 client-secret: secret-001
-	 keycloak-realm: https://example.com/auth/realms/example
-	 domain: example
+   client-id: client-001
+   client-secret: secret-001
+   keycloak-realm: https://example.com/auth/realms/example
 `,
 }, {
 	about: "no client-id",
 	yaml: `
 identity-providers:
  - type: keycloak 
-	 client-secret: secret-001
-	 keycloak-realm: https://example.com/auth/realms/example
+   client-secret: secret-001
+   keycloak-realm: https://example.com/auth/realms/example
 `,
 	expectError: `cannot unmarshal keycloak configuration: client-id not specified`,
 }, {
@@ -40,21 +39,20 @@ identity-providers:
 	yaml: `
 identity-providers:
  - type: keycloak 
-	 client-id: client-001
-	 keycloak-realm: https://example.com/auth/realms/example
+   client-id: client-001
+   keycloak-realm: https://example.com/auth/realms/example
 `,
 	expectError: `cannot unmarshal keycloak configuration: client-secret not specified`,
-},{
+}, {
 	about: "no keycloak-realm",
 	yaml: `
 identity-providers:
  - type: keycloak
-	 client-id: client-001
-	 client-secret: secret-001
+   client-id: client-001
+   client-secret: secret-001
 `,
 	expectError: `cannot unmarshal keycloak configuration: keycloak-realm not specified`,
-}
-}
+}}
 
 func TestConfig(t *testing.T) {
 	c := qt.New(t)

--- a/idp/keycloak/keycloak_test.go
+++ b/idp/keycloak/keycloak_test.go
@@ -1,3 +1,4 @@
+// Copyright 2020 Mark Klein <mdklein@gmail.com>
 // Copyright 2017 Canonical Ltd.
 // Licensed under the AGPLv3, see LICENCE file for details.
 

--- a/idp/keycloak/keycloak_test.go
+++ b/idp/keycloak/keycloak_test.go
@@ -26,6 +26,14 @@ identity-providers:
    keycloak-realm: https://example.com/auth/realms/example
 `,
 }, {
+  about: "another good config",
+  yaml: `
+identity-providers:
+ - type: keycloak 
+   client-id: client-001
+   keycloak-realm: https://example.com/auth/realms/example
+`,
+}, {
 	about: "no client-id",
 	yaml: `
 identity-providers:
@@ -34,15 +42,6 @@ identity-providers:
    keycloak-realm: https://example.com/auth/realms/example
 `,
 	expectError: `cannot unmarshal keycloak configuration: client-id not specified`,
-}, {
-	about: "no client-secret",
-	yaml: `
-identity-providers:
- - type: keycloak 
-   client-id: client-001
-   keycloak-realm: https://example.com/auth/realms/example
-`,
-	expectError: `cannot unmarshal keycloak configuration: client-secret not specified`,
 }, {
 	about: "no keycloak-realm",
 	yaml: `


### PR DESCRIPTION
Hello,

My organization uses Keycloak (https://www.keycloak.org/) for identity management which would be nice to target for MaaS (w/RBAC) service.

I based this on the existing google/azure oidc idps. I extended them a bit to specify the keycloak realm URL in the config file. 

I'm currently using this for our MasS deployment in a testbed environment and thought it might be useful to others.

Cheers,
Mark