### PR TITLE
Handle cookie Path when Candid is not running in root path, but in a sublocation

### DIFF
--- a/charm/layer-candid/config.yaml
+++ b/charm/layer-candid/config.yaml
@@ -75,3 +75,9 @@ options:
       be active before it is forgotten. The value must be a time duration
       specified as a decimal number followed by a unit from ns, us,
       ms, s, m, h for the time units between nanosecond and hour.
+  skip-location-for-cookie-paths:
+    type: boolean
+    default: false
+    description: |
+      If true, it leaves cookies' Path value absolute, instead of
+      seeting it relative to the path in the location config.

--- a/cmd/candidsrv/main.go
+++ b/cmd/candidsrv/main.go
@@ -132,6 +132,7 @@ func serveIdentity(conf *config.Config, params candid.ServerParams) error {
 	params.APIMacaroonTimeout = conf.APIMacaroonTimeout.Duration
 	params.DischargeMacaroonTimeout = conf.DischargeMacaroonTimeout.Duration
 	params.DischargeTokenTimeout = conf.DischargeTokenTimeout.Duration
+	params.SkipLocationForCookiePaths = conf.SkipLocationForCookiePaths
 	srv, err := candid.NewServer(
 		params,
 		candid.V1,

--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,10 @@ type Config struct {
 	// DischargeTokenTimeout is the maximum age a discharge token can
 	// get before it becomes invalid.
 	DischargeTokenTimeout DurationString `yaml:"discharge-token-timeout"`
+
+	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
+	// be set relative to the Location Path or not.
+	SkipLocationForCookiePaths bool `yaml:"skip-location-for-cookie-paths"`
 }
 
 // TLSConfig returns a TLS configuration to be used for serving

--- a/idp/idp.go
+++ b/idp/idp.go
@@ -81,6 +81,10 @@ type InitParams struct {
 
 	// Template contains the templates loaded in the identity server.
 	Template *template.Template
+
+	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
+	// be set relative to the Location Path or not.
+	SkipLocationForCookiePaths bool
 }
 
 // IdentityProvider is the interface that is satisfied by all identity providers.

--- a/idp/idputil/idputil.go
+++ b/idp/idputil/idputil.go
@@ -240,3 +240,15 @@ func ServiceURL(location, dest string) string {
 	lu.Path = path.Join(lu.Path, u.Path)
 	return lu.String()
 }
+
+// CookiePathRelativeToLocation returns the Login Cookie Path
+// relative to the sub-path in the location URL given.
+func CookiePathRelativeToLocation(cookiePath, location string) string {
+	relativePath := ""
+	u, err := url.Parse(location)
+	if err == nil {
+		relativePath = u.Path
+	}
+
+	return relativePath + cookiePath
+}

--- a/idp/idputil/idputil.go
+++ b/idp/idputil/idputil.go
@@ -243,12 +243,14 @@ func ServiceURL(location, dest string) string {
 
 // CookiePathRelativeToLocation returns the Login Cookie Path
 // relative to the sub-path in the location URL given.
-func CookiePathRelativeToLocation(cookiePath, location string) string {
-	relativePath := ""
-	u, err := url.Parse(location)
-	if err == nil {
-		relativePath = u.Path
+// If skipLocation = true, then it's a no-op.
+func CookiePathRelativeToLocation(cookiePath, location string, skipLocation bool) string {
+	if skipLocation {
+		return cookiePath
 	}
-
-	return relativePath + cookiePath
+	u, err := url.Parse(location)
+	if err != nil {
+		return cookiePath
+	}
+	return u.Path + cookiePath
 }

--- a/idp/openid/openid-connect.go
+++ b/idp/openid/openid-connect.go
@@ -223,7 +223,8 @@ func (idp *openidConnectIdentityProvider) callback(ctx context.Context, w http.R
 		return errgo.Mask(err)
 	}
 	ls.ProviderID = user.ProviderID
-	state, err := idp.initParams.Codec.SetCookie(w, idputil.LoginCookieName, idputil.CookiePathRelativeToLocation(idputil.LoginCookiePath, idp.initParams.Location), ls)
+	cookiePath := idputil.CookiePathRelativeToLocation(idputil.LoginCookiePath, idp.initParams.Location, idp.initParams.SkipLocationForCookiePaths)
+	state, err := idp.initParams.Codec.SetCookie(w, idputil.LoginCookieName, cookiePath, ls)
 	if err != nil {
 		return errgo.Mask(err)
 	}

--- a/idp/openid/openid-connect.go
+++ b/idp/openid/openid-connect.go
@@ -223,7 +223,7 @@ func (idp *openidConnectIdentityProvider) callback(ctx context.Context, w http.R
 		return errgo.Mask(err)
 	}
 	ls.ProviderID = user.ProviderID
-	state, err := idp.initParams.Codec.SetCookie(w, idputil.LoginCookieName, idputil.LoginCookiePath, ls)
+	state, err := idp.initParams.Codec.SetCookie(w, idputil.LoginCookieName, idputil.CookiePathRelativeToLocation(idputil.LoginCookiePath, idp.initParams.Location), ls)
 	if err != nil {
 		return errgo.Mask(err)
 	}

--- a/internal/discharger/idp.go
+++ b/internal/discharger/idp.go
@@ -44,15 +44,16 @@ func initIDPs(ctx context.Context, params initIDPParams) error {
 			return errgo.Mask(err)
 		}
 		if err := ip.Init(ctx, idp.InitParams{
-			Store:                 params.Store,
-			KeyValueStore:         kvStore,
-			Oven:                  params.Oven,
-			Codec:                 params.Codec,
-			Location:              params.Location,
-			URLPrefix:             params.Location + "/login/" + ip.Name(),
-			DischargeTokenCreator: params.DischargeTokenCreator,
-			VisitCompleter:        params.VisitCompleter,
-			Template:              params.Template,
+			Store:                      params.Store,
+			KeyValueStore:              kvStore,
+			Oven:                       params.Oven,
+			Codec:                      params.Codec,
+			Location:                   params.Location,
+			URLPrefix:                  params.Location + "/login/" + ip.Name(),
+			DischargeTokenCreator:      params.DischargeTokenCreator,
+			VisitCompleter:             params.VisitCompleter,
+			Template:                   params.Template,
+			SkipLocationForCookiePaths: params.SkipLocationForCookiePaths,
 		}); err != nil {
 			return errgo.Mask(err)
 		}

--- a/internal/discharger/login.go
+++ b/internal/discharger/login.go
@@ -73,8 +73,9 @@ type loginRequest struct {
 func (h *handler) Login(p httprequest.Params, req *loginRequest) error {
 	// Store the requested discharge ID in a session cookie so that
 	// when the redirect comes back to login-complete we know the
-	// login was initiated in this session.
-	state, err := h.params.codec.SetCookie(p.Response, waitCookieName, "/login-complete", waitState{
+	// login was initiated in this session. In case Candid is running in a sub-path,
+	// we handle that as well.
+	state, err := h.params.codec.SetCookie(p.Response, waitCookieName, idputil.CookiePathRelativeToLocation("/login-complete", h.params.Location), waitState{
 		DischargeID: req.DischargeID,
 	})
 	if err != nil {
@@ -114,7 +115,7 @@ type redirectLoginRequest struct {
 // identity provider which the user must then choose to start the login
 // process.
 func (h *handler) RedirectLogin(p httprequest.Params, req *redirectLoginRequest) error {
-	state, err := h.params.codec.SetCookie(p.Response, idputil.LoginCookieName, idputil.LoginCookiePath, idputil.LoginState{
+	state, err := h.params.codec.SetCookie(p.Response, idputil.LoginCookieName, idputil.CookiePathRelativeToLocation(idputil.LoginCookiePath, h.params.Location), idputil.LoginState{
 		ReturnTo: req.ReturnTo,
 		State:    req.State,
 		Expires:  time.Now().Add(15 * time.Minute),

--- a/internal/discharger/login.go
+++ b/internal/discharger/login.go
@@ -73,9 +73,9 @@ type loginRequest struct {
 func (h *handler) Login(p httprequest.Params, req *loginRequest) error {
 	// Store the requested discharge ID in a session cookie so that
 	// when the redirect comes back to login-complete we know the
-	// login was initiated in this session. In case Candid is running in a sub-path,
-	// we handle that as well.
-	state, err := h.params.codec.SetCookie(p.Response, waitCookieName, idputil.CookiePathRelativeToLocation("/login-complete", h.params.Location), waitState{
+	// login was initiated in this session.
+	cookiePath := idputil.CookiePathRelativeToLocation("/login-complete", h.params.Location, h.params.SkipLocationForCookiePaths)
+	state, err := h.params.codec.SetCookie(p.Response, waitCookieName, cookiePath, waitState{
 		DischargeID: req.DischargeID,
 	})
 	if err != nil {
@@ -115,7 +115,8 @@ type redirectLoginRequest struct {
 // identity provider which the user must then choose to start the login
 // process.
 func (h *handler) RedirectLogin(p httprequest.Params, req *redirectLoginRequest) error {
-	state, err := h.params.codec.SetCookie(p.Response, idputil.LoginCookieName, idputil.CookiePathRelativeToLocation(idputil.LoginCookiePath, h.params.Location), idputil.LoginState{
+	cookiePath := idputil.CookiePathRelativeToLocation(idputil.LoginCookiePath, h.params.Location, h.params.SkipLocationForCookiePaths)
+	state, err := h.params.codec.SetCookie(p.Response, idputil.LoginCookieName, cookiePath, idputil.LoginState{
 		ReturnTo: req.ReturnTo,
 		State:    req.State,
 		Expires:  time.Now().Add(15 * time.Minute),

--- a/internal/discharger/login_sublocation_test.go
+++ b/internal/discharger/login_sublocation_test.go
@@ -1,0 +1,61 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package discharger_test
+
+import (
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
+
+	"github.com/canonical/candid/idp"
+	"github.com/canonical/candid/idp/static"
+	"github.com/canonical/candid/internal/candidtest"
+	"github.com/canonical/candid/internal/discharger"
+	"github.com/canonical/candid/internal/identity"
+)
+
+const sublocationPath = "/sublocation"
+
+func TestLoginWithSublocation(t *testing.T) {
+	qtsuite.Run(qt.New(t), &loginSuite{})
+}
+
+type loginSuite struct {
+	srv *candidtest.Server
+}
+
+func (s *loginSuite) Init(c *qt.C) {
+	store := candidtest.NewStore()
+	sp := store.ServerParams()
+	sp.IdentityProviders = []idp.IdentityProvider{
+		static.NewIdentityProvider(static.Params{
+			Name:   "test",
+			Domain: "test",
+			Icon:   "/static/static1.bmp",
+		}),
+	}
+	s.srv = candidtest.NewServerWithSublocation(c, sp, map[string]identity.NewAPIHandlerFunc{
+		"discharger": discharger.NewAPIHandler,
+	}, sublocationPath)
+}
+
+func (s *loginSuite) TestLoginCookiePathContainsServerSublocation(c *qt.C) {
+	req, err := http.NewRequest("GET", sublocationPath+"/login", nil)
+	c.Assert(err, qt.IsNil)
+	req.Header.Set("Accept", "application/json")
+	resp := s.srv.Do(c, req)
+	defer resp.Body.Close()
+	c.Assert(resp.StatusCode, qt.Equals, http.StatusOK)
+
+	cookies := resp.Cookies()
+	c.Assert(len(cookies) > 0, qt.IsTrue)
+
+	for _, cookie := range cookies {
+		dir := filepath.Dir(cookie.Path)
+		c.Assert(dir, qt.Equals, sublocationPath)
+	}
+}

--- a/internal/identity/server.go
+++ b/internal/identity/server.go
@@ -281,6 +281,10 @@ type ServerParams struct {
 	// DischargeTokenTimeout is the maximum life of a Discharge
 	// token.
 	DischargeTokenTimeout time.Duration
+
+	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
+	// be set relative to the Location Path or not.
+	SkipLocationForCookiePaths bool
 }
 
 type HandlerParams struct {

--- a/server.go
+++ b/server.go
@@ -126,6 +126,10 @@ type ServerParams struct {
 	// DischargeTokenTimeout is the maximum life of a Discharge
 	// token.
 	DischargeTokenTimeout time.Duration
+
+	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
+	// be set relative to the Location Path or not.
+	SkipLocationForCookiePaths bool
 }
 
 // NewServer returns a new handler that handles identity service requests and


### PR DESCRIPTION
See issue #25, because cookies now specify a Path, and the path is absolute, they are not being sent anymore if the service is running from a subpath. In this stack, I am fixing that by taking the path part of the Location into account. 

Because we might still want the old behavior in certain deployments (e.g. ReverseProxyCookiePath setting in apache), we are parameterizing the change, defaulting to enabled.

Sanity checked on a local apache2 & candid deployment as well, issue looks fixed.