### PR TITLE
internal/discharge: use email to select identity provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,6 +300,7 @@ performing an interactive login.
   client-id: 43444f68-3666-4f95-bd34-6fc24b108019
   client-secret: tXV2SRFflAGT9sUdxkdIi7mwfmQ=
   hidden: true
+  match-email-addr: @example.com$
 ```
 
 The ADFS identity provider uses OpenID Connect to authenticate with an
@@ -320,6 +321,12 @@ scope in order to retrieve the required profile information.
 The `hidden` value is an optional value that can be used to not list
 this identity provider in the list of possible identity providers when
 performing an interactive login.
+
+The `match-email-addr` value is a regular expression that can be used to
+select the identity provider using an email address. If configured when
+a user attempts to login via an email address the address will be
+checked against the regular expression and if they match the identity
+provider will be used to perform the login.
 
 ### Google OpenID Connect
 ```yaml
@@ -468,6 +475,7 @@ performing an interactive login.
       password: password2
       groups: [group3, group4]
   hidden: false
+  match-email-addr: @example.com$
 ```
 
 The `static` identity provider is meant for testing and allows defining a set of
@@ -493,6 +501,12 @@ of the users defined by the identity provider.
 The `hidden` value is an optional value that can be used to not list
 this identity provider in the list of possible identity providers when
 performing an interactive login.
+
+The `match-email-addr` value is a regular expression that can be used to
+select the identity provider using an email address. If configured when
+a user attempts to login via an email address the address will be
+checked against the regular expression and if they match the identity
+provider will be used to perform the login.
 
 Charm Configuration
 -------------------

--- a/idp/adfs/adfs.go
+++ b/idp/adfs/adfs.go
@@ -63,6 +63,10 @@ type Params struct {
 	// Hidden is set if the IDP should be hidden from interactive
 	// prompts.
 	Hidden bool `yaml:"hidden"`
+
+	// MatchEmailAddr is a regular expression that is used to determine if
+	// this identity provider can be used for a particular user email.
+	MatchEmailAddr string `yaml:"match-email-addr"`
 }
 
 // NewIdentityProvider creates an ADFS identity provider with the
@@ -75,14 +79,15 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 		p.Domain = p.Name
 	}
 	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
-		Name:         p.Name,
-		Issuer:       p.URL,
-		Domain:       p.Domain,
-		Description:  p.Description,
-		Icon:         p.Icon,
-		Scopes:       []string{oidc.ScopeOpenID, "email", "profile"},
-		ClientID:     p.ClientID,
-		ClientSecret: p.ClientSecret,
-		Hidden:       p.Hidden,
+		Name:           p.Name,
+		Issuer:         p.URL,
+		Domain:         p.Domain,
+		Description:    p.Description,
+		Icon:           p.Icon,
+		Scopes:         []string{oidc.ScopeOpenID, "email", "profile"},
+		ClientID:       p.ClientID,
+		ClientSecret:   p.ClientSecret,
+		Hidden:         p.Hidden,
+		MatchEmailAddr: p.MatchEmailAddr,
 	})
 }

--- a/templates/authentication-required
+++ b/templates/authentication-required
@@ -29,10 +29,29 @@
             <h1 class="p-heading--four">Login with</h1>
           </div>
           <hr class="u-sv1">
+  {{if .Error}}
+            <div class="p-notification--negative">
+              <p class="p-notification__response">
+                <span class="p-notification__status">Error:</span>{{.Error}}
+              </p>
+            </div>
+  {{end}}
+  {{ if .UseEmail }}
+          <div>
+            <form method="post" action="{{ .WithEmailURL }}">
+              <label for="email">Email address</label>
+              <input type="email" id="email" name="email">
+              <button type="submit">Continue</button>
+            </form>
+          </div>
+  {{ end }}
   {{ range .IDPs }}
           <div>
             <a href="{{.URL}}" class="p-button--neutral" data-idp-name="{{.Name}}" data-idp-domain="{{.Domain}}" style="width: 100%">{{.Description}}</a>
           </div>
+  {{ end }}
+  {{ if .ShowEmailLink }}
+          <a href="{{.WithEmailURL}}">Login with email address...</a>
   {{ end }}
         </div>
       </div>


### PR DESCRIPTION
Add an option to the "authentication required" dialogue that allows
a user to choose an identity provider by entering an email address.
This option is only supported by the static and adfs identity provider
types currently.