### PR TITLE
config: add enable-email-login setting

### DIFF
--- a/charm/layer-candid/config.yaml
+++ b/charm/layer-candid/config.yaml
@@ -22,6 +22,12 @@ options:
     description: |
       The maximum age a discharge token can get before it becomes
       invalid.
+  enable-email-login:
+    type: boolean
+    default: false
+    description: |
+      Enable the "login with email address" functionality on the
+      authentication required page.
   http-proxy:
     type: string
     default: ""

--- a/charm/layer-candid/metadata.yaml
+++ b/charm/layer-candid/metadata.yaml
@@ -10,8 +10,9 @@ tags:
   - authentication
   - identity
 series:
-  - xenial
+  - focal
   - bionic
+  - xenial
 peers:
   candid:
     interface: candid

--- a/charm/layer-candid/reactive/candid.py
+++ b/charm/layer-candid/reactive/candid.py
@@ -52,9 +52,11 @@ def write_config_file():
         "api-macaroon-timeout": cc["api-macaroon-timeout"],
         "discharge-macaroon-timeout": cc["discharge-macaroon-timeout"],
         "discharge-token-timeout": cc["discharge-token-timeout"],
+        "enable-email-login": cc["enable-email-login"],
         "logging-config": cc["logging-config"],
         "private-addr": hookenv.unit_private_ip(),
         "rendezvous-timeout": cc["rendezvous-timeout"],
+        "skip-location-for-cookie-paths": cc["skip-location-for-cookie-paths"],
     }
     if cc["admin-agent-public-key"]:
         config["admin-agent-public-key"] = cc["admin-agent-public-key"]

--- a/cmd/candidsrv/config.yaml
+++ b/cmd/candidsrv/config.yaml
@@ -49,3 +49,4 @@ identity-providers:
       groups:
        - group2
        - group3
+enable-email-login: true

--- a/cmd/candidsrv/main.go
+++ b/cmd/candidsrv/main.go
@@ -133,6 +133,7 @@ func serveIdentity(conf *config.Config, params candid.ServerParams) error {
 	params.DischargeMacaroonTimeout = conf.DischargeMacaroonTimeout.Duration
 	params.DischargeTokenTimeout = conf.DischargeTokenTimeout.Duration
 	params.SkipLocationForCookiePaths = conf.SkipLocationForCookiePaths
+	params.EnableEmailLogin = conf.EnableEmailLogin
 	srv, err := candid.NewServer(
 		params,
 		candid.V1,

--- a/config/config.go
+++ b/config/config.go
@@ -112,6 +112,10 @@ type Config struct {
 	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
 	// be set relative to the Location Path or not.
 	SkipLocationForCookiePaths bool `yaml:"skip-location-for-cookie-paths"`
+
+	// EnableEmailLogin enables the login with email address link on the
+	// authentication required page.
+	EnableEmailLogin bool `yaml:"enable-email-login"`
 }
 
 // TLSConfig returns a TLS configuration to be used for serving

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -94,6 +94,7 @@ redirect-login-whitelist:
 api-macaroon-timeout: 2h
 discharge-macaroon-timeout: 24h
 discharge-token-timeout: 6h
+enable-email-login: true
 `
 
 func readConfig(c *qt.C, content string) (*config.Config, error) {
@@ -173,6 +174,7 @@ func TestRead(t *testing.T) {
 		APIMacaroonTimeout:       config.DurationString{Duration: 2 * time.Hour},
 		DischargeMacaroonTimeout: config.DurationString{Duration: 24 * time.Hour},
 		DischargeTokenTimeout:    config.DurationString{Duration: 6 * time.Hour},
+		EnableEmailLogin:         true,
 	})
 }
 

--- a/idp/keycloak/keycloak.go
+++ b/idp/keycloak/keycloak.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultProviderName = "keycloak"
+	defaultProviderName   = "keycloak"
 	defaultProviderDomain = "KEYCLOAK"
 )
 

--- a/idp/keycloak/keycloak_test.go
+++ b/idp/keycloak/keycloak_test.go
@@ -27,8 +27,8 @@ identity-providers:
    keycloak-realm: https://example.com/auth/realms/example
 `,
 }, {
-  about: "another good config",
-  yaml: `
+	about: "another good config",
+	yaml: `
 identity-providers:
  - type: keycloak 
    client-id: client-001

--- a/idp/openid/openid-connect.go
+++ b/idp/openid/openid-connect.go
@@ -113,10 +113,10 @@ func NewOpenIDConnectIdentityProvider(params OpenIDConnectParams) idp.IdentityPr
 }
 
 type openidConnectIdentityProvider struct {
-	params     OpenIDConnectParams
-	initParams idp.InitParams
-	provider   *oidc.Provider
-	config     *oauth2.Config
+	params         OpenIDConnectParams
+	initParams     idp.InitParams
+	provider       *oidc.Provider
+	config         *oauth2.Config
 	matchEmailAddr *regexp.Regexp
 }
 

--- a/internal/discharger/login.go
+++ b/internal/discharger/login.go
@@ -171,7 +171,7 @@ func (h *handler) authChoice(w http.ResponseWriter, req *http.Request, state, do
 		IDPs:          idps,
 		Error:         errorMessage,
 		UseEmail:      useEmail,
-		ShowEmailLink: domain == "" && !useEmail,
+		ShowEmailLink: h.params.EnableEmailLogin && domain == "" && !useEmail,
 		WithEmailURL:  h.params.Location + "/login-email?state=" + state,
 	}
 	if err := h.params.Template.ExecuteTemplate(w, "authentication-required", authParams); err != nil {

--- a/internal/discharger/login_test.go
+++ b/internal/discharger/login_test.go
@@ -76,9 +76,9 @@ func (s *loginSuite) Init(c *qt.C) {
 			Icon: "/static/static1.bmp",
 		}),
 		static.NewIdentityProvider(static.Params{
-			Name:   "test2",
-			Domain: "test2",
-			Icon:   "/static/static2.bmp",
+			Name:           "test2",
+			Domain:         "test2",
+			Icon:           "/static/static2.bmp",
 			MatchEmailAddr: "@example.com$",
 		}),
 		static.NewIdentityProvider(static.Params{

--- a/internal/identity/server.go
+++ b/internal/identity/server.go
@@ -285,6 +285,10 @@ type ServerParams struct {
 	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
 	// be set relative to the Location Path or not.
 	SkipLocationForCookiePaths bool
+
+	// EnableEmailLogin enables the login with email address link on the
+	// authentication required page.
+	EnableEmailLogin bool
 }
 
 type HandlerParams struct {

--- a/server.go
+++ b/server.go
@@ -130,6 +130,10 @@ type ServerParams struct {
 	// SkipLocationForCookiePaths instructs if the Cookie Paths are to
 	// be set relative to the Location Path or not.
 	SkipLocationForCookiePaths bool
+
+	// EnableEmailLogin enables the login with email address link on the
+	// authentication required page.
+	EnableEmailLogin bool
 }
 
 // NewServer returns a new handler that handles identity service requests and


### PR DESCRIPTION
Add a new configuration setting to enable the "login with email"
functionality, making it disabled by default.