### PR TITLE
idp/usso: Allow more than one simultaneous usso IDP

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,15 +142,42 @@ for details on the agent login protocol.
 ### UbuntuSSO
 ```yaml
 - type: usso
+  name: usso
+  domain: external
+  description: Ubuntu SSO
   launchpad-teams:
     - group1
     - group2
+  staging: false
+  fixed-username: false
 ```
 
 The UbuntuSSO identity provider is an interactive identity provider
 that uses OpenID with UbuntuSSO to log in.
 
-The launchpad-teams contains any private launchpad teams that candid needs to know about.
+The `name` parameter specifies the name of the provider, this should be
+a short name that reflects the name of the system being logged in to.
+The name is used in some URLS and is best if it consists only of
+lower-case letters.
+
+The `domain` is a string added to the names of users logging in through
+this identity provider. The user jsmith for example would be changed
+to jsmith@example in the configuration above. If no domain is
+specified the username will remain unchanged.
+
+The `description` is optional and will be used if the identity provider
+is presented in a human readable form, if this is not set "Ubuntu SSO"
+will be used.
+
+The `launchpad-teams` contains any private launchpad teams that candid
+needs to know about.
+
+If `staging` is true then the identity provider will use staging
+instances of Ubuntu SSO and launchpad for the identity information.
+
+If `fixed-username` is true then username changes returned from Ubuntu
+SSO will not be automatically reflected when a user authenticates. The
+username in candid will remain fixed to the username that is first used.
 
 ### UbuntuSSO OAuth
 ```yaml

--- a/idp/usso/usso_test.go
+++ b/idp/usso/usso_test.go
@@ -49,12 +49,19 @@ func (s *ussoSuite) TestConfig(c *qt.C) {
 	configYaml := `
 identity-providers:
  - type: usso
+ - type: usso
+   name: usso2
+   description: Another USSO
+   staging: true
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(configYaml), &conf)
 	c.Assert(err, qt.IsNil)
-	c.Assert(conf.IdentityProviders, qt.HasLen, 1)
+	c.Assert(conf.IdentityProviders, qt.HasLen, 2)
 	c.Assert(conf.IdentityProviders[0].Name(), qt.Equals, "usso")
+	c.Assert(conf.IdentityProviders[0].Description(), qt.Equals, "Ubuntu SSO")
+	c.Assert(conf.IdentityProviders[1].Name(), qt.Equals, "usso2")
+	c.Assert(conf.IdentityProviders[1].Description(), qt.Equals, "Another USSO")
 }
 
 func (s *ussoSuite) TestName(c *qt.C) {


### PR DESCRIPTION
Make the name and description configurable to allow for many usso IDPs
to be configured at the same time.