### PR TITLE
idp: add default icon urls to idps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,7 @@ for details on the agent login protocol.
 - type: usso
   name: usso
   domain: external
+  icon: /static/images/usso-icon.bmp
   description: Ubuntu SSO
   launchpad-teams:
     - group1
@@ -169,6 +170,11 @@ The `description` is optional and will be used if the identity provider
 is presented in a human readable form, if this is not set "Ubuntu SSO"
 will be used.
 
+The `icon` is optional and specifies the location of an icon to display
+when presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default icon for Ubuntu SSO will be used.
+
 The `launchpad-teams` contains any private launchpad teams that candid
 needs to know about.
 
@@ -193,6 +199,7 @@ uses a previously obtained UbuntuSSO OAuth token to log in.
   name: canonistack
   domain: canonistack
   description: Canonistack
+  icon: /static/images/keystone-icon.bmp
   url: https://keystone.canonistack.canonical.com:443/
   hidden: false
 ```
@@ -216,6 +223,11 @@ specified the username will remain unchanged.
 The `description` is optional and will be used if the identity provider
 is presented in a human readable form, if this is not set the name
 will be used.
+
+The `icon` is optional and specifies the location of an icon to display
+when presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default icon for keystone will be used.
 
 The `url` is the location of the keystone server that will be used to
 authenticate the user.
@@ -299,6 +311,7 @@ authenticate the user.
 ### Azure OpenID Connect
 ```yaml
 - type: azure
+  icon: /static/images/azure-icon.bmp
   client-id: 43444f68-3666-4f95-bd34-6fc24b108019
   client-secret: tXV2SRFflAGT9sUdxkdIi7mwfmQ=
   hidden: false
@@ -308,6 +321,11 @@ The Azure identity provider uses OpenID Connect to log in using Microsoft
 credentials via https://login.live.com. When a user first logs in with
 this IDP they will be prompted to create a new identity. The new identity
 must have a unique username and will be in the domain "@azure".
+
+The `icon` is optional and specifies the location of an icon to display
+when presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default icon for azure will be used.
 
 The `client-id` and `client-secret` parameters must be specified and
 are created by registering the candid instance as an application at
@@ -323,6 +341,7 @@ performing an interactive login.
 - type: adfs
   name: example
   domain: example
+  icon: /static/images/adfs.bmp
   url: https://adfs.example.com
   client-id: 43444f68-3666-4f95-bd34-6fc24b108019
   client-secret: tXV2SRFflAGT9sUdxkdIi7mwfmQ=
@@ -332,6 +351,11 @@ performing an interactive login.
 
 The ADFS identity provider uses OpenID Connect to authenticate with an
 Active Directory Federation Services deployment.
+
+The `icon` is optional and specifies the location of an icon to display
+when presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default generic OpenID icon will be used.
 
 The required `url` parameter specifies the location of the ADFS OpenID
 Connect service. OpenID Connect Discovery will be performed using this
@@ -358,6 +382,7 @@ provider will be used to perform the login.
 ### Google OpenID Connect
 ```yaml
 - type: google
+  icon: /static/images/google-icon.bmp
   client-id: 483156874216-rh0j89ltslhuqirk7deh70d3mp49kdvq.apps.googleusercontent.com
   client-secret: 8aENrwCL/+PU87ROkXwMB+09xe0=
   hidden: false
@@ -373,6 +398,11 @@ are created by registering the candid instance as an application
 at https://console.developers.google.com/apis/credentials. When
 registering the application the authorized redirect URLs should include
 `$CANDID_URL/login/google/callback`.
+
+The `icon` is optional and specifies the location of an icon to display
+when presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default icon for google will be used.
 
 The `hidden` value is an optional value that can be used to not list
 this identity provider in the list of possible identity providers when
@@ -393,6 +423,11 @@ credentials. When a user first logs in with this IDP they will be prompted
 to create a new identity. The new identity must have a unique username
 and will be in the domain specified "@domain", otherwise default to "@KEYCLOAK".
 
+The `icon` is optional and specifies the location of an icon to display
+when presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default generic OpenID icon will be used.
+
 The 'keycloak-realm and `client-id` parameters must be specified and should be 
 provided by the keycloak service administrator. An optional client-secret may
 also be required which the keycloak service administrator should provide.
@@ -410,6 +445,7 @@ performing an interactive login.
 - type: ldap
   name: ldap
   description: LDAP Login
+  icon: /static/images/ldap-icon.bmp
   domain: example
   url: ldap://ldap.example.com/dc=example,dc=com
   ca-cert: |
@@ -445,6 +481,11 @@ allows them to be identified. The name will be used in the login URL.
 `description` (optional) provides a human readable description of the
 identity provider. If it is not set it will default to the value of
 `name`.
+
+`icon` (optional) specifies the location of an icon to display when
+presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default generic LDAP icon will be used.
 
 `domain` (optional) is the domain in which all identities will be
 created. If this is not set then no domain is used.
@@ -490,6 +531,7 @@ performing an interactive login.
   name: static
   domain: mydomain
   description: Static Identity Provider
+  icon: /static/images/static-icon.bmp
   users:
     user1:
       name: User One
@@ -521,6 +563,11 @@ created. If this is not set then no domain is used.
 `description` (optional) provides a human readable description of the
 identity provider. If it is not set it will default to the value of
 `name`.
+
+`icon` (optional) specifies the location of an icon to display when
+presenting the identity-provider options to a user. It this is set
+to URL path then that path should be relative to the candid service's
+location. If this is not set a default icon will be used.
 
 `users` contains a static mapping of username to user entries for all
 of the users defined by the identity provider.

--- a/idp/azure/azure.go
+++ b/idp/azure/azure.go
@@ -66,6 +66,9 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 	if p.Domain == "" {
 		p.Domain = "azure"
 	}
+	if p.Icon == "" {
+		p.Icon = "/static/images/icons/azure.svg"
+	}
 
 	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
 		Name:         p.Name,

--- a/idp/google/google.go
+++ b/idp/google/google.go
@@ -67,6 +67,9 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 	if p.Domain == "" {
 		p.Domain = "google"
 	}
+	if p.Icon == "" {
+		p.Icon = "/static/images/icons/google.svg"
+	}
 	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
 		Name:         p.Name,
 		Issuer:       "https://accounts.google.com",

--- a/idp/keystone/keystone.go
+++ b/idp/keystone/keystone.go
@@ -86,6 +86,9 @@ func newIdentityProvider(p Params) identityProvider {
 	if p.Description == "" {
 		p.Description = p.Name
 	}
+	if p.Icon == "" {
+		p.Icon = "/static/images/icons/keystone.svg"
+	}
 	return identityProvider{
 		params: p,
 		client: keystone.NewClient(p.URL),

--- a/idp/keystone/keystone_test.go
+++ b/idp/keystone/keystone_test.go
@@ -43,7 +43,12 @@ func (s *keystoneSuite) TestKeystoneIdentityProviderDescription(c *qt.C) {
 }
 
 func (s *keystoneSuite) TestIconURL(c *qt.C) {
-	c.Assert(s.idp.IconURL(), qt.Equals, "")
+	idp := keystoneidp.NewIdentityProvider(keystoneidp.Params{})
+	params := s.idptest.InitParams(c, idpPrefix)
+	params.Location = "https://www.example.com/candid"
+	err := idp.Init(s.idptest.Ctx, params)
+	c.Assert(err, qt.IsNil)
+	c.Assert(idp.IconURL(), qt.Equals, "https://www.example.com/candid/static/images/icons/keystone.svg")
 }
 
 func (s *keystoneSuite) TestAbsoluteIconURL(c *qt.C) {

--- a/idp/ldap/ldap.go
+++ b/idp/ldap/ldap.go
@@ -120,6 +120,9 @@ func NewIdentityProvider(p Params) (idp.IdentityProvider, error) {
 	if p.Description == "" {
 		p.Description = p.Name
 	}
+	if p.Icon == "" {
+		p.Icon = "/static/images/icons/ldap.svg"
+	}
 
 	if p.UserQueryAttrs.ID == "" {
 		return nil, errgo.Newf("missing 'id' config parameter in 'user-query-attrs'")

--- a/idp/ldap/ldap_test.go
+++ b/idp/ldap/ldap_test.go
@@ -191,9 +191,13 @@ func (s *ldapSuite) TestDescription(c *qt.C) {
 }
 
 func (s *ldapSuite) TestIconURL(c *qt.C) {
-	idp, err := ldap.NewIdentityProvider(getSampleParams())
+	i, err := ldap.NewIdentityProvider(getSampleParams())
 	c.Assert(err, qt.IsNil)
-	c.Assert(idp.IconURL(), qt.Equals, "")
+	err = i.Init(context.Background(), idp.InitParams{
+		Location: "https://www.example.com/candid",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(i.IconURL(), qt.Equals, "https://www.example.com/candid/static/images/icons/ldap.svg")
 }
 
 func (s *ldapSuite) TestAbsoluteIconURL(c *qt.C) {

--- a/idp/openid/openid-connect.go
+++ b/idp/openid/openid-connect.go
@@ -115,6 +115,9 @@ func NewOpenIDConnectIdentityProvider(params OpenIDConnectParams) idp.IdentityPr
 	if params.Description == "" {
 		params.Description = params.Name
 	}
+	if params.Icon == "" {
+		params.Icon = "/static/images/icons/openid.svg"
+	}
 	if len(params.Scopes) == 0 {
 		params.Scopes = []string{oidc.ScopeOpenID}
 	}

--- a/idp/static/static.go
+++ b/idp/static/static.go
@@ -81,6 +81,9 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 	if p.Description == "" {
 		p.Description = p.Name
 	}
+	if p.Icon == "" {
+		p.Icon = "/static/images/icons/static.svg"
+	}
 	var matchEmailAddr *regexp.Regexp
 	if p.MatchEmailAddr != "" {
 		var err error

--- a/idp/static/static_test.go
+++ b/idp/static/static_test.go
@@ -75,8 +75,12 @@ func (s *staticSuite) TestDescription(c *qt.C) {
 }
 
 func (s *staticSuite) TestIconURL(c *qt.C) {
-	idp := static.NewIdentityProvider(getSampleParams())
-	c.Assert(idp.IconURL(), qt.Equals, "")
+	i := static.NewIdentityProvider(getSampleParams())
+	err := i.Init(context.Background(), idp.InitParams{
+		Location: "https://www.example.com/candid",
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(i.IconURL(), qt.Equals, "https://www.example.com/candid/static/images/icons/static.svg")
 }
 
 func (s *staticSuite) TestAbsoluteIconURL(c *qt.C) {

--- a/idp/usso/usso.go
+++ b/idp/usso/usso.go
@@ -75,6 +75,9 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 	if p.Description == "" {
 		p.Description = "Ubuntu SSO"
 	}
+	if p.Icon == "" {
+		p.Icon = "/static/images/icons/usso.svg"
+	}
 	return &identityProvider{
 		groupCache: cache.New(10 * time.Minute),
 		groupMonitor: prometheus.NewSummary(prometheus.SummaryOpts{

--- a/idp/usso/usso_test.go
+++ b/idp/usso/usso_test.go
@@ -77,7 +77,12 @@ func (s *ussoSuite) TestDescription(c *qt.C) {
 }
 
 func (s *ussoSuite) TestIconURL(c *qt.C) {
-	c.Assert(s.idp.IconURL(), qt.Equals, "")
+	idp := usso.NewIdentityProvider(usso.Params{})
+	params := s.idptest.InitParams(c, idpPrefix)
+	params.Location = "https://www.example.com/candid"
+	err := idp.Init(s.idptest.Ctx, params)
+	c.Assert(err, qt.IsNil)
+	c.Assert(idp.IconURL(), qt.Equals, "https://www.example.com/candid/static/images/icons/usso.svg")
 }
 
 func (s *ussoSuite) TestAbsoluteIconURL(c *qt.C) {


### PR DESCRIPTION
Where appropriate set default icon urls for each idp. Also ensure that
the documentation includes notes about the icon configuration where it
may be used.