### PR TITLE
internal/discharger: implement trusted domains

### DIFF
--- a/cmd/candidsrv/main.go
+++ b/cmd/candidsrv/main.go
@@ -140,6 +140,7 @@ func serveIdentity(conf *config.Config, params candid.ServerParams) error {
 	params.PrivateAddr = conf.PrivateAddr
 	params.AdminAgentPublicKey = conf.AdminAgentPublicKey
 	params.RedirectLoginWhitelist = conf.RedirectLoginWhitelist
+	params.RedirectLoginTrustedDomains = conf.RedirectLoginTrustedDomains
 	params.APIMacaroonTimeout = conf.APIMacaroonTimeout.Duration
 	params.DischargeMacaroonTimeout = conf.DischargeMacaroonTimeout.Duration
 	params.DischargeTokenTimeout = conf.DischargeTokenTimeout.Duration

--- a/config/config.go
+++ b/config/config.go
@@ -97,6 +97,11 @@ type Config struct {
 	// login.
 	RedirectLoginWhitelist []string `yaml:"redirect-login-whitelist"`
 
+	// RedirectLoginTrustedDomains contains a list of domains that are
+	// trusted to be used as return_to URLs during an interactive
+	// login.
+	RedirectLoginTrustedDomains []string `yaml:"redirect-login-trusted-domains"`
+
 	// APIMacaroonTimeout is the maximum age an API macaroon can get
 	// before requiring re-authorization.
 	APIMacaroonTimeout DurationString `yaml:"api-macaroon-timeout"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -91,6 +91,9 @@ no-proxy: localhost,.example.com
 redirect-login-whitelist:
 - https://example.com/1
 - https://example.com/2
+redirect-login-trusted-domains:
+- www.example.com
+- "*.example.net"
 api-macaroon-timeout: 2h
 discharge-macaroon-timeout: 24h
 discharge-token-timeout: 6h
@@ -170,6 +173,10 @@ func TestRead(t *testing.T) {
 		RedirectLoginWhitelist: []string{
 			"https://example.com/1",
 			"https://example.com/2",
+		},
+		RedirectLoginTrustedDomains: []string{
+			"www.example.com",
+			"*.example.net",
 		},
 		APIMacaroonTimeout:       config.DurationString{Duration: 2 * time.Hour},
 		DischargeMacaroonTimeout: config.DurationString{Duration: 24 * time.Hour},

--- a/internal/identity/server.go
+++ b/internal/identity/server.go
@@ -271,6 +271,12 @@ type ServerParams struct {
 	// login.
 	RedirectLoginWhitelist []string
 
+	// RedirectLoginTrustedDomains contains a list of domain names that
+	// are fully trusted to be used as return_to URLs during an
+	// interactive login. If the domain starts with the sequence "*."
+	// then all subdomains of the subsequent domain will be trusted.
+	RedirectLoginTrustedDomains []string
+
 	// APIMacaroonTimeout is the maximum life of an API macaroon.
 	APIMacaroonTimeout time.Duration
 

--- a/server.go
+++ b/server.go
@@ -116,6 +116,12 @@ type ServerParams struct {
 	// login.
 	RedirectLoginWhitelist []string
 
+	// RedirectLoginTrustedDomains contains a list of domain names that
+	// are fully trusted to be used as return_to URLs during an
+	// interactive login. If the domain starts with the sequence "*."
+	// then all subdomains of the subsequent domain will be trusted.
+	RedirectLoginTrustedDomains []string
+
 	// APIMacaroonTimeout is the maximum life of an API macaroon.
 	APIMacaroonTimeout time.Duration
 


### PR DESCRIPTION
Add the concept of trusted domains that can be used in the redirect flow
and will allow any path with the domain, and optionally all subdomains
to be trusted return_to addresses.