### PR TITLE
Remove the email option

### DIFF
--- a/templates/authentication-required
+++ b/templates/authentication-required
@@ -70,7 +70,6 @@
 </div>
 
 {{ if .ShowEmailLink }}
-        <a href="{{.WithEmailURL}}">Or login with email address</a>
 {{ end }}
       </div>
     </div>


### PR DESCRIPTION
I am not sure this is the best way to do it, but I think we should remove the option to log in via email since that's not functional atm.