### PR TITLE
Add parameter to specify AzureAD login URL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -372,6 +372,7 @@ authenticate the user.
 ```yaml
 - type: azure
   icon: /static/images/azure-icon.bmp
+  loginurl: https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad
   client-id: 43444f68-3666-4f95-bd34-6fc24b108019
   client-secret: tXV2SRFflAGT9sUdxkdIi7mwfmQ=
   hidden: false
@@ -391,6 +392,10 @@ The `client-id` and `client-secret` parameters must be specified and
 are created by registering the candid instance as an application at
 https://apps.dev.microsoft.com. When registering the application the
 redirect URLs should include `$CANDID_URL/login/azure/callback` .
+
+The `loginurl` parameter is optional and used to specify an Azure AD
+tenant login URL in the form of https://login.microsoftonline.com/{TENANT_Id}
+or https://sts.windows.net/{TENANT_ID}
 
 The `hidden` value is an optional value that can be used to not list
 this identity provider in the list of possible identity providers when

--- a/idp/azure/azure.go
+++ b/idp/azure/azure.go
@@ -56,6 +56,11 @@ type Params struct {
 	// Hidden is set if the IDP should be hidden from interactive
 	// prompts.
 	Hidden bool `yaml:"hidden"`
+
+	//The Azure login URL
+	//For Azure AD it should be set to https://login.microsoftonline.com/${TENANT_ID} or https://sts.windows.net/${TENANT_ID}/
+	//Default to "https://login.live.com" (consumer account login)
+	LoginUrl string `yam:"loginurl"`
 }
 
 // NewIdentityProvider creates an azure identity provider with the
@@ -70,10 +75,13 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 	if p.Icon == "" {
 		p.Icon = "/static/images/icons/azure.svg"
 	}
+	if p.LoginUrl == "" {
+		p.LoginUrl = "https://login.live.com/"
+	}
 
 	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
 		Name:            p.Name,
-		Issuer:          "https://login.live.com",
+		Issuer:          p.LoginUrl,
 		Description:     p.Description,
 		Icon:            p.Icon,
 		Domain:          p.Domain,

--- a/idp/azure/azure.go
+++ b/idp/azure/azure.go
@@ -57,10 +57,10 @@ type Params struct {
 	// prompts.
 	Hidden bool `yaml:"hidden"`
 
-	//The Azure login URL
+	//LoginURL is the Azure login URL
 	//For Azure AD it should be set to https://login.microsoftonline.com/${TENANT_ID} or https://sts.windows.net/${TENANT_ID}/
 	//Default to "https://login.live.com" (consumer account login)
-	LoginUrl string `yam:"loginurl"`
+	LoginURL string `yam:"loginurl"`
 }
 
 // NewIdentityProvider creates an azure identity provider with the
@@ -75,13 +75,13 @@ func NewIdentityProvider(p Params) idp.IdentityProvider {
 	if p.Icon == "" {
 		p.Icon = "/static/images/icons/azure.svg"
 	}
-	if p.LoginUrl == "" {
-		p.LoginUrl = "https://login.live.com/"
+	if p.LoginURL == "" {
+		p.LoginURL = "https://login.live.com/"
 	}
 
 	return openid.NewOpenIDConnectIdentityProvider(openid.OpenIDConnectParams{
 		Name:            p.Name,
-		Issuer:          p.LoginUrl,
+		Issuer:          p.LoginURL,
 		Description:     p.Description,
 		Icon:            p.Icon,
 		Domain:          p.Domain,


### PR DESCRIPTION
## Description

The new parameter `loginurl` allows to setup the Azure IDP to authenticate against Azure AD applications.
It still default to https://login.live.com if `loginurl` is not set.

<!-- If this PR addresses a particular issue, please uncomment the line below: -->
<!-- Addresses *JIRA/GitHub issue number* -->

## Engineering checklist
*Check only items that apply*

- [x] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Independent change*

