### PR TITLE
Improve readability for multiple login methods

### DIFF
--- a/static/css/vanilla.css
+++ b/static/css/vanilla.css
@@ -48,13 +48,18 @@ body {
 
 .sso-buttons {
   margin-top: 1.5rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
 }
 
 .sso-button {
   border-color: #cdcdcd;
   padding-bottom: 1rem;
   padding-top: 1rem;
-  width: 100%;
+  width: 195px;
+  height: 9rem;
 }
 
 .sso-icon {
@@ -66,6 +71,11 @@ body {
   width: auto;
 }
 
+.u-truncate--multiline {
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
 @media only screen and (min-width: 620px) {
   .sso-buttons {
     overflow: hidden;
@@ -73,8 +83,6 @@ body {
 
   .sso-button {
     float: left;
-    height: 125px;
-    width: 125px;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/static/css/vanilla.css
+++ b/static/css/vanilla.css
@@ -58,8 +58,12 @@ body {
   border-color: #cdcdcd;
   padding-bottom: 1rem;
   padding-top: 1rem;
-  width: 195px;
+  width: 100%;
   height: 9rem;
+  margin-right: 0 !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .sso-icon {
@@ -82,14 +86,7 @@ body {
   }
 
   .sso-button {
-    float: left;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .sso-button:nth-child(3n) {
-    margin-right: 0 !important;
+    width: 195px;
   }
 
   .sso-button--wide {

--- a/templates/authentication-required
+++ b/templates/authentication-required
@@ -61,7 +61,7 @@
         {{ $length := len .IDPs }}
         {{ range .IDPs }}
                 <a href="{{.URL}}" class="p-button--neutral sso-button {{ if eq $length 1 }}sso-button--wide{{ end }}" data-idp-name="{{.Name}}" data-idp-domain="{{.Domain}}">
-                  <div class="u-truncate" title="{{.Description}}">
+                  <div class="u-truncate--multiline" title="{{.Description}}">
                     {{ if .Icon }}<p class="sso-icon"><img class="sso-icon__image" src="{{.Icon}}" alt="" width="32" height="32"></p>{{ end }}
                         {{.Description}}
                   </div>


### PR DESCRIPTION
## Description

Make frontend changes to improve readability of login cards with longer text.

<!-- If this PR addresses a particular issue, please uncomment the line below: -->
Addresses https://github.com/canonical/marketplace-tribe/issues/1925

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*

## Test instructions

Ensure the cards look OK with:
- a single provider (`.sso-button--wide`)
- multiple rows (copy and paste the elements in browser inspector)
- long domains (again, use the browser inspector to update the text within the card).
 
Screenshots provided for visual validation.

## Notes for code reviewers
You must roll > 10 in HTML and CSS proficiency.

## Screenshots
### Single item - wide
![image](https://user-images.githubusercontent.com/479384/194100061-f6f86250-c1fe-4f5b-9b1c-de83fd45bc78.png)

### Two items - long domain
![image](https://user-images.githubusercontent.com/479384/194100424-1fbb5a38-537d-47ea-9d29-3d4db90159ec.png)

### Two items - long domain - small screen
![image](https://user-images.githubusercontent.com/479384/194100560-cbaeb162-3399-4377-9986-f9345cc3dc25.png)

### Multline
![image](https://user-images.githubusercontent.com/479384/194100850-28463455-5ad9-432a-a552-b991112fd213.png)

### Multiline - small screen
![image](https://user-images.githubusercontent.com/479384/194100954-20748900-968f-4552-84be-e7cb703affcf.png)
