### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 GIT_COMMIT := $(shell git rev-parse --verify HEAD)
 GIT_VERSION := $(shell git describe --dirty)
 ARCH := $(shell dpkg --print-architecture)
+AUTH ?= ssh
 
 DEPENDENCIES := build-essential bzr
 SNAP_DEPENDENCIES := go snapcraft
@@ -69,15 +70,15 @@ else
 endif
 
 image:
-    DOCKER_BUILDKIT=1 \
-    docker build \
-        --build-arg AUTH_TYPE=ssh \
-        --cache-from candid:latest \
-        --progress=plain \
-        --secret id=ghuser,env=GH_USER \
-        --secret id=ghpat,env=GH_PAT \
-        --ssh default \
-        . -f ./docker/Dockerfile -t candid
+	DOCKER_BUILDKIT=1 \
+	docker build \
+		--build-arg AUTH_TYPE=$(AUTH) \
+		--cache-from candid:latest \
+		--progress=plain \
+		--secret id=ghuser,env=GH_USER \
+		--secret id=ghpat,env=GH_PAT \
+		--ssh default \
+		. -f ./Dockerfile -t candid
 
 help:
 	@echo -e 'Identity service - list of make targets:\n'


### PR DESCRIPTION
## Description

Small PR to address a few issues in the Makefile when building the docker image:
- Dockerfile location was incorrect when building the docker image.
- Added the ability to set the auth type from the command line when building candid docker image i.e. `make image AUTH=pat`, previously was fixed with ssh auth.
- Used tabs instead of spaces (had issues when running make because of this).

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*