### PR TITLE
Removed need for Github credentials to build Docker images

### DIFF
--- a/.github/workflows/oci-image.yaml
+++ b/.github/workflows/oci-image.yaml
@@ -2,10 +2,6 @@ name: BuildOCIImage
 on:
   workflow_dispatch:
 
-env:
-  GH_USER: ${{ secrets.GH_USER }}
-  GH_AUTH: ${{ secrets.GH_AUTH }}
-
 jobs:
   candid-oci-image:
     runs-on: ubuntu-latest
@@ -13,9 +9,6 @@ jobs:
       - uses: actions/checkout@v3
       - run: git fetch --prune --unshallow
       - uses: ./.github/workflows/setupgo118amd64
-        with:
-          user: ${{ secrets.GH_USER }}
-          pat: ${{ secrets.GH_AUTH }}
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
       - name: Setup version and commit
@@ -30,12 +23,8 @@ jobs:
           target: deploy-env
           tags: candid:latest
           build-args: |
-            AUTH_TYPE=pat
             GIT_COMMIT=${{ env.GIT_COMMIT }}
             VERSION=${{ env.VERSION }}
-          secrets: |
-            "ghuser=${{ env.GH_USER }}"
-            "ghpat=${{ env.GH_AUTH }}"
           outputs: |
             type=docker,dest=candid-image.tar
       - uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,26 +10,12 @@ RUN bash < <(curl -SL -v https://raw.githubusercontent.com/moovweb/gvm/${GVM_VER
     gvm install go$(cat go.mod | sed -n "/^go/p" | cut -d ' ' -f 2)  -B && \
     gvm use go$(cat go.mod | sed -n "/^go/p" | cut -d ' ' -f 2)  --default
 
-FROM build as build-with-github-auth
-ARG AUTH_TYPE
+FROM build as build-env
 ARG GIT_COMMIT
 ARG VERSION
 WORKDIR /usr/src/candid
 SHELL ["/bin/bash", "-c"]
 COPY . .
-RUN --mount=type=secret,id=ghuser \
-    --mount=type=secret,id=ghpat \ 
-    --mount=type=ssh \ 
-    if [ "$AUTH_TYPE" = "pat" ]; then \
-    echo "machine github.com login $(cat /run/secrets/ghuser) password $(cat /run/secrets/ghpat)" > $HOME/.netrc && \
-    echo "PAT auth selected"; \
-    elif [ "$AUTH_TYPE" = "ssh" ]; then \
-    git config --global user.name $(cat /run/secrets/ghuser) && \
-    mkdir -p -m 0600 ~/.ssh && \
-    echo $(ssh-keyscan github.com) >> ~/.ssh/known_hosts && \
-    git config --global --add url."git@github.com:".insteadOf "https://github.com/" && \
-    echo "SSH auth selected"; \
-    fi
 RUN --mount=type=ssh source /root/.gvm/scripts/gvm && ./scripts/set-version.sh
 RUN --mount=type=ssh source /root/.gvm/scripts/gvm && go mod vendor
 RUN --mount=type=ssh source /root/.gvm/scripts/gvm && GOBIN=/usr/src/candid go install gopkg.in/macaroon-bakery.v2/cmd/bakery-keygen@latest
@@ -42,11 +28,11 @@ RUN apt-get -qq update && apt-get -qq install -y ca-certificates
 WORKDIR /root/
 RUN mkdir www
 RUN mkdir logs
-COPY --from=build-with-github-auth /usr/src/candid/candidsrv .
-COPY --from=build-with-github-auth /usr/src/candid/candid .
-COPY --from=build-with-github-auth /usr/src/candid/bakery-keygen .
-COPY --from=build-with-github-auth /usr/src/candid/static ./www/static/
-COPY --from=build-with-github-auth /usr/src/candid/templates ./www/templates
+COPY --from=build-env /usr/src/candid/candidsrv .
+COPY --from=build-env /usr/src/candid/candid .
+COPY --from=build-env /usr/src/candid/bakery-keygen .
+COPY --from=build-env /usr/src/candid/static ./www/static/
+COPY --from=build-env /usr/src/candid/templates ./www/templates
 RUN touch config.yaml
 ENTRYPOINT ["./candidsrv"]
 CMD ["config.yaml"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@
 GIT_COMMIT := $(shell git rev-parse --verify HEAD)
 GIT_VERSION := $(shell git describe --dirty)
 ARCH := $(shell dpkg --print-architecture)
-AUTH ?= ssh
 
 DEPENDENCIES := build-essential bzr
 SNAP_DEPENDENCIES := go snapcraft
@@ -72,12 +71,7 @@ endif
 image:
 	DOCKER_BUILDKIT=1 \
 	docker build \
-		--build-arg AUTH_TYPE=$(AUTH) \
 		--cache-from candid:latest \
-		--progress=plain \
-		--secret id=ghuser,env=GH_USER \
-		--secret id=ghpat,env=GH_PAT \
-		--ssh default \
 		. -f ./Dockerfile -t candid
 
 help:


### PR DESCRIPTION
## Description

Removed the need to have Github PAT or SSH keys to build the docker image. This wasn't required and is now simplified.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*