### PR TITLE
Update Candid dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 
 GIT_COMMIT := $(shell git rev-parse --verify HEAD)
 GIT_VERSION := $(shell git describe --dirty)
+GO_VERSION := $(shell go list -f {{.GoVersion}} -m)
 ARCH := $(shell dpkg --print-architecture)
 
 DEPENDENCIES := build-essential bzr
@@ -71,7 +72,9 @@ endif
 image:
 	DOCKER_BUILDKIT=1 \
 	docker build \
-		--cache-from candid:latest \
+		--build-arg="GIT_COMMIT=$(GIT_COMMIT)" \
+		--build-arg="VERSION=$(GIT_VERSION)" \
+		--build-arg="GO_VERSION=$(GO_VERSION)" \
 		. -f ./Dockerfile -t candid
 
 help:

--- a/go.mod
+++ b/go.mod
@@ -149,4 +149,4 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-go 1.18
+go 1.20


### PR DESCRIPTION
## Description

Update the Candid Dockerfile to remove GVM (Go Version Manager). Also bumps the go version to 1.20

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [x] Independent change*