### PR TITLE
lint new issues only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
+          only-new-issues: true
           skip-pkg-cache: true
           skip-build-cache: true
 


### PR DESCRIPTION
## Description

Linter fails nearly on all PRs and people are forced to ignore it, which makes the concept of linting useless. Now each new PR  would only show failures introduced by that PR.

## Engineering checklist
*Check only items that apply*

- [ ] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Independent change*
