### PR TITLE
add documentation for generic openid-connect provider

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -440,6 +440,33 @@ a user attempts to login via an email address the address will be
 checked against the regular expression and if they match the identity
 provider will be used to perform the login.
 
+### Generic OpenID Connect
+
+```yaml
+- type: openid-connect
+  domain: example
+  client-id: <client-id-value>
+  client-secret: <client-secret-value>
+  issuer: https://example.com/application/o/client/
+  scopes: ["openid", "profile", "email"]
+  hidden: false
+  description: "Generic OIDC"
+```
+
+The generic OpenID Connect identity provider uses any OIDC compliant issuer (e.g. Authentik) to login using configured credentials.
+
+The `domain` is a string added to the names of users logging in through this identity provider. The user jsmith for example would be changed to jsmith@example in the configuration above. If no domain is specified the username will remain unchanged.
+
+The `client-id` and `client-secret` must be specified and will be available through the OIDC provider.
+
+The `issuer` is required and must match the issuer value in the `/.well-known/openid-configuration` endpoint exactly.
+
+It is recommended to include the `scopes` value with at least the openid, profile, and email scopes configured. If this value is not set, Candid will default to only using the openid scope, which may require users to input name and email upon their first login.
+
+The `hidden` value is an optional value that can be used to not list this identity provider in the list of possible identity providers when performing an interactive login.
+
+The `description` value is an optional value that can be used to customize the name of the provider as it appears in the Candid login portal.
+
 ### Google OpenID Connect
 
 ```yaml


### PR DESCRIPTION
## Description

This PR adds documentation for the openid-connect identity provider type. This type allows for integration with identity providers that are not explicitly supported. One such case raised by a customer was Authentik. 

Although Authentik's OIDC implementation is interchangeable with Keycloak, the Keycloak provider could not be used because it is hard-coded to only request the openid and profile scopes. Authentik requires the email scope to be explicitly requested in order to get a user's email address, whereas this scope is implicitly added by default in Keycloak clients.

The `openid-connect` type is likely to work with many other OIDC providers as well, so it seems best to document its usage rather than to create a separate identity provider just for Authentik.

<!-- If this PR addresses a particular issue, please uncomment the line below: -->
<!-- Addresses *JIRA/GitHub issue number* -->

## Engineering checklist
*Check only items that apply*

- [x] Documentation updated
- [ ] Covered by unit tests
- [ ] Covered by integration tests
- [ ] Independent change*